### PR TITLE
Fix slide out text wrapping

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -120,7 +120,6 @@
 
       render() {
         return html`
-          <h1>${this.title}</h1>
           <ul>
             ${this.items.map(this.item)}
           </ul>
@@ -164,7 +163,27 @@
           .items=${[1, 2, 3, 4, 5, 6].map(i => `CD-ROM ${i}`)}
         ></menu-content>
       `,
-    }, {
+    },
+    {
+      icon: html`
+        <ia-icon icon="donate" style="--iconFillColor: #f00"></ia-icon>
+      `,
+      label: 'Very long label that will wrap itself to the next line',
+      id: 'long-label',
+      followable: true,
+      component: html`
+        <menu-content
+          .title='Software menu'
+          .items=${[
+        '1Bacon ipsum dolor amet pork chop spare ribs pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+        '2Bacon ipsum dolor amet pork chop spare ribs pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+        '3Bacon ipsum dolor amet pork chop spare ribs pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+        '4pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+        '5pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+      ]}
+        ></menu-content>`,
+    },
+    {
       icon: html`
         <ia-icon icon="donate" style="--iconFillColor: #f00"></ia-icon>
       `,

--- a/demo/index.html
+++ b/demo/index.html
@@ -180,6 +180,8 @@
         '3Bacon ipsum dolor amet pork chop spare ribs pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
         '4pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
         '5pork loin, chislic brisket beef ribs pork belly alcatra chicken pork hamburger meatloaf fatback. Pancetta ham hock buffalo salami ground round meatball. Shankle picanha short loin beef meatball prosciutto buffalo corned beef leberkas. Chislic tri-tip boudin pork chop fatback tenderloin frankfurter. Pig beef ribs boudin rump. Andouille doner burgdoggen ham hock short ribs ball tip, corned beef meatloaf tenderloin venison. Brisket bacon drumstick venison chicken boudin.',
+        'foo',
+        'bar',
       ]}
         ></menu-content>`,
     },

--- a/demo/index.html
+++ b/demo/index.html
@@ -204,7 +204,7 @@
       const menuSliderElement = html`
         <ia-menu-slider
           .menus=${menus}
-          @ItemNavMenuClosed=${closeCB}
+          @animateMenuOpen=${closeCB}
           ?open=${menuOpen}
           ?animateMenuOpen=${true}
         ></ia-menu-slider>`;

--- a/demo/index.html
+++ b/demo/index.html
@@ -201,7 +201,13 @@
         console.log('Drawer Closed', event);
         menuOpen = false;
       };
-      const menuSliderElement = html`<ia-menu-slider .menus=${menus} @ItemNavMenuClosed=${closeCB} ?open=${menuOpen}></ia-menu-slider>`;
+      const menuSliderElement = html`
+        <ia-menu-slider
+          .menus=${menus}
+          @ItemNavMenuClosed=${closeCB}
+          ?open=${menuOpen}
+          ?animateMenuOpen=${true}
+        ></ia-menu-slider>`;
 
       const toggleMenu = () => {
         menuOpen = !menuOpen;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.8",
+  "version": "0.1.9-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9-alpha3",
+  "version": "0.1.9-alpha4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9-alpha4",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Menu slider used in ia-topnav",
   "author": "ia-menu-slider",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9-alpha3",
+  "version": "0.1.9-alpha4",
   "description": "Menu slider used in ia-topnav",
   "author": "ia-menu-slider",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.8",
+  "version": "0.1.9-alpha3",
   "description": "Menu slider used in ia-topnav",
   "author": "ia-menu-slider",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "0.1.9-alpha4",
+  "version": "0.1.9",
   "description": "Menu slider used in ia-topnav",
   "author": "ia-menu-slider",
   "license": "MIT",

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -102,7 +102,7 @@ export class IAMenuSlider extends LitElement {
       <header class="${headerClass}">
         <div class="details">
           <h3>${label}</h3>
-          ${menuDetails ? html`<span class="extra-details">${menuDetails}</span>` : nothing}
+          <span class="extra-details">${menuDetails}</span>
         </div>
         ${actionSection}
         ${this.closeButton}

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -102,7 +102,7 @@ export class IAMenuSlider extends LitElement {
       <header class="${headerClass}">
         <div class="details">
           <h3>${label}</h3>
-          <span class="extra-details">${menuDetails}</span>
+          ${menuDetails ? html`<span class="extra-details">${menuDetails}</span>` : nothing}
         </div>
         ${actionSection}
         ${this.closeButton}

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -5,7 +5,7 @@ import '@internetarchive/icon-collapse-sidebar/icon-collapse-sidebar.js';
 import './menu-button.js';
 
 const sliderEvents = {
-  closeDrawer: 'ItemNavMenuClosed',
+  closeDrawer: 'menuSliderClosed',
 };
 export class IAMenuSlider extends LitElement {
   static get styles() {
@@ -18,6 +18,7 @@ export class IAMenuSlider extends LitElement {
       open: { type: Boolean },
       selectedMenu: { type: String },
       animateMenuOpen: { type: Boolean },
+      manuallyHandleClose: { type: Boolean },
     };
   }
 
@@ -28,6 +29,7 @@ export class IAMenuSlider extends LitElement {
     this.open = false;
     this.selectedMenu = '';
     this.animateMenuOpen = false;
+    this.manuallyHandleClose = true;
   }
 
   /**
@@ -43,7 +45,9 @@ export class IAMenuSlider extends LitElement {
    * closes menu drawer
    */
   closeMenu() {
-    this.open = false;
+    if (!this.manuallyHandleClose) {
+      this.open = false;
+    }
     const { closeDrawer } = sliderEvents;
     const drawerClosed = new CustomEvent(closeDrawer, {
       detail: this.selectedMenuDetails,

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -121,6 +121,7 @@ export class IAMenuSlider extends LitElement {
   /** @inheritdoc */
   render() {
     return html`
+      <div class="main">
       <div class="menu ${this.sliderDetailsClass}">
         ${this.closeButton}
         <ul class="menu-list">
@@ -128,10 +129,13 @@ export class IAMenuSlider extends LitElement {
         </ul>
         <div class="content ${this.selectedMenuClass}" @menuTypeSelected=${this.setSelectedMenu}>
           ${this.renderMenuHeader}
-          <section class="selected-menu">
-            ${this.selectedMenuComponent}
+          <section>
+            <div class="selected-menu">
+              ${this.selectedMenuComponent}
+            </div>
           </section>
         </div>
+      </div>
       </div>
     `;
   }

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -29,7 +29,7 @@ export class IAMenuSlider extends LitElement {
     this.open = false;
     this.selectedMenu = '';
     this.animateMenuOpen = false;
-    this.manuallyHandleClose = true;
+    this.manuallyHandleClose = false;
   }
 
   /**

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -64,12 +64,12 @@ export class IAMenuSlider extends LitElement {
 
   get sliderDetailsClass() {
     const animate = this.animateMenuOpen ? 'animate' : '';
-    const state = this.open ? 'open' : 'closed';
+    const state = this.open ? 'open' : '';
     return `${animate} ${state}`;
   }
 
   get selectedMenuClass() {
-    return this.selectedMenu ? 'open' : 'closed';
+    return this.selectedMenu ? 'open' : '';
   }
 
   get menuItems() {

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -2,6 +2,7 @@ import { css } from 'lit-element';
 
 const menuButtonWidth = css`42px`;
 const sliderWidth = css`var(--menuWidth, 320px)`;
+const transitionTiming = css`var(--animationTiming, 200ms)`;
 
 export default css`
 
@@ -24,7 +25,7 @@ export default css`
     color: var(--primaryTextColor);
     background: var(--menuSliderBg);
     transform: translateX(calc(${sliderWidth} * -1));
-    transition: transform var(--animationTiming) ease-out;
+    transition: transform ${transitionTiming} ease-out;
   }
   .menu:before {
     position: absolute;
@@ -93,7 +94,7 @@ export default css`
     left: ${menuButtonWidth};
     z-index: 1;
     transform: translateX(calc(${sliderWidth} * -1));
-    transition: transform var(--animationTiming) ease-out;
+    transition: transform ${transitionTiming} ease-out;
     background: var(--activeButtonBg);
     border-right: .2rem solid;
     border-color: var(--subpanelRightBorderColor);

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -97,7 +97,7 @@ export default css`
     background: var(--activeButtonBg);
     border-right: .2rem solid;
     border-color: var(--subpanelRightBorderColor);
-    padding: .5rem 0 .5rem .5rem;
+    padding: .5rem 0 0 .5rem;
   }
 
   .open {
@@ -115,10 +115,10 @@ export default css`
   }
 
   .content section {
-    height: 96%;
+    height: 97%;
     position: relative;
     width: 100%;
-    padding-bottom: 4%;
+    padding-bottom: 3%;
   }
 
   .content .selected-menu {

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -124,10 +124,9 @@ export default css`
   }
 
   .content section {
-    height: 96%;
+    height: 100%;
     position: relative;
     width: 100%;
-    padding-bottom: 4%;
   }
 
   .content .selected-menu {

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -38,13 +38,17 @@ export default css`
     background: var(--menuSliderBg);
   }
 
+  .menu > button.close {
+    right: 0.7rem;
+  }
+
   button {
     outline: none;
     cursor: pointer;
   }
 
   header {
-    margin: .2rem 0 .5rem 0;
+    margin: 0 0 .5rem 0;
   }
 
   header * {

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -1,6 +1,7 @@
 import { css } from 'lit-element';
 
 const menuButtonWidth = css`42px`;
+const sliderWidth = css`var(--menuWidth, 320px)`;
 
 export default css`
 
@@ -9,13 +10,13 @@ export default css`
     top: 0;
     left: 0;
     bottom: 0;
-    width: 100%;
+    width: ${sliderWidth};
     padding: .5rem .5rem .5rem 0;
     box-sizing: border-box;
     font-size: 1.4rem;
     color: var(--primaryTextColor);
     background: var(--menuSliderBg);
-    transform: translateX(calc(100% * -1));
+    transform: translateX(calc(${sliderWidth} * -1));
     transition: transform var(--animationTiming) ease-out;
   }
   .menu:before {
@@ -84,7 +85,7 @@ export default css`
     bottom: 0;
     left: ${menuButtonWidth};
     z-index: 1;
-    transform: translateX(calc(100% * -1));
+    transform: translateX(calc(${sliderWidth} * -1));
     transition: transform var(--animationTiming) ease-out;
     background: var(--activeButtonBg);
     border-right: .2rem solid;

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -13,6 +13,10 @@ export default css`
     height: 100%;
   }
 
+  .animate {
+    transition: transform ${transitionTiming} ease-out;
+  }
+
   .menu {
     position: absolute;
     top: 0;
@@ -25,8 +29,8 @@ export default css`
     color: var(--primaryTextColor);
     background: var(--menuSliderBg);
     transform: translateX(calc(${sliderWidth} * -1));
-    transition: transform ${transitionTiming} ease-out;
   }
+
   .menu:before {
     position: absolute;
     top: 0;

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -115,10 +115,10 @@ export default css`
   }
 
   .content section {
-    height: 97%;
+    height: 96%;
     position: relative;
     width: 100%;
-    padding-bottom: 3%;
+    padding-bottom: 4%;
   }
 
   .content .selected-menu {
@@ -126,7 +126,7 @@ export default css`
     position: absolute;
     top: 0;
     width: 100%;
-    padding-bottom: 1rem;
+    padding-bottom: 2rem;
     height: inherit;
   }
 

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -5,13 +5,20 @@ const sliderWidth = css`var(--menuWidth, 320px)`;
 
 export default css`
 
+  .main {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
   .menu {
     position: absolute;
     top: 0;
     left: 0;
     bottom: 0;
     width: ${sliderWidth};
-    padding: .5rem .5rem .5rem 0;
+    padding: .5rem .5rem 0 0;
     box-sizing: border-box;
     font-size: 1.4rem;
     color: var(--primaryTextColor);
@@ -107,15 +114,24 @@ export default css`
     margin-bottom: .2rem;
   }
 
+  .content section {
+    height: 96%;
+    position: relative;
+    width: 100%;
+    padding-bottom: 4%;
+  }
+
   .content .selected-menu {
     overflow: auto;
     position: absolute;
-    width: 98%;
-    bottom: 0;
-    top: 4rem;
+    top: 0;
+    width: 100%;
+    padding-bottom: 1rem;
+    height: inherit;
   }
 
   .content .selected-menu > * {
     display: block;
+    padding-bottom: 3rem;
   }
 `;


### PR DESCRIPTION
To work with item navigator the way it was designed, we have to turn off a couple of things:
- how the slider manages closing
- how the slider animates open/close

Solution:
add 2 flags to mitigate those abilities:
- on close, if one `manuallyHandleClose` , then the app does not toggle close, it just emits the event for the consumer to handle
- manually toggle open/close animation with `animateMenuOpen` flag so that item navigator's transitions/animations are the ONLY layer of animation being used.

To test: go to `https://www-isa.archive.org/details/goody/page/92/mode/2up` - log in with archive.org creds, and toggle side menu

![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/7840857/105104595-6eae9a80-5a67-11eb-8dab-7fd84b396e62.gif)
