### PR TITLE
Header Action button: can now update to a new component if necessary

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -45,6 +45,7 @@
 
     section {
       position: relative;
+      width: 320px;
     }
   </style>
 </head>
@@ -129,7 +130,7 @@
     let showPrimary = true;
     const primaryActionButton = html`
         <button
-          style='color: white;'
+        style='--iconFillColor: aquamarine;'
           @click=${e => extraActionClickHandler(e)}
         >
           <ia-icon-volumes></ia-icon-volumes>
@@ -137,10 +138,10 @@
       `;
     const secondaryActionButton = html`
         <button
-          style='color: white;'
+          style='--iconFillColor: red;'
           @click=${e => extraActionClickHandler(e)}
         >
-          <ia-icon icon="software"></ia-icon>
+          <ia-icon-volumes></ia-icon-volumes>
         </button>
       `;
 customElements.define('menu-content', MenuContent);

--- a/demo/index.html
+++ b/demo/index.html
@@ -127,6 +127,8 @@
         `;
       }
     }
+    customElements.define('menu-content', MenuContent);
+
     let showPrimary = true;
     const primaryActionButton = html`
         <button
@@ -144,7 +146,6 @@
           <ia-icon-volumes></ia-icon-volumes>
         </button>
       `;
-customElements.define('menu-content', MenuContent);
     let menus = [{
       icon: html`
         <ia-icon icon="audio"></ia-icon>

--- a/demo/index.html
+++ b/demo/index.html
@@ -126,21 +126,31 @@
         `;
       }
     }
-    customElements.define('menu-content', MenuContent);
-    const menus = [{
+    let showPrimary = true;
+    const primaryActionButton = html`
+        <button
+          style='color: white;'
+          @click=${e => extraActionClickHandler(e)}
+        >
+          <ia-icon-volumes></ia-icon-volumes>
+        </button>
+      `;
+    const secondaryActionButton = html`
+        <button
+          style='color: white;'
+          @click=${e => extraActionClickHandler(e)}
+        >
+          <ia-icon icon="software"></ia-icon>
+        </button>
+      `;
+customElements.define('menu-content', MenuContent);
+    let menus = [{
       icon: html`
         <ia-icon icon="audio"></ia-icon>
       `,
       title: 'Audio Menu',
       menuDetails: '(100,000,000 tracks)',
-      actionButton: html`
-        <button
-          style='color: white;'
-          @click=${e => console.log('CLICK EXTRA ACTION', e)}
-        >
-          <ia-icon-volumes></ia-icon-volumes>
-        </button>
-      `,
+      actionButton: primaryActionButton,
       label: 'Audio',
       id: 'audio',
       component: html`
@@ -194,6 +204,18 @@
       followable: true,
       href: '#',
     }];
+
+    function extraActionClickHandler(e) {
+      const audio = menus.find(m => m.title === 'Audio Menu');
+      showPrimary = !showPrimary;
+
+      audio.actionButton = showPrimary ? primaryActionButton : secondaryActionButton;
+      const newMenus = menus;
+      menus = [...newMenus];
+
+      const menuSlider = document.querySelector('ia-menu-slider');
+      menuSlider.menus = menus;
+    }
 
     (function toggleScope() {
       let menuOpen = false;

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -112,14 +112,16 @@ export class IAMenuSlider extends LitElement {
   get renderMenuHeader() {
     const { label = '', menuDetails = '' } = this.selectedMenuDetails || {};
     const headerClass = this.selectedMenuAction ? 'with-secondary-action' : '';
-
+    const actionBlock = this.selectedMenuAction
+      ? html`<span class="custom-action">${this.selectedMenuAction}</span>`
+      : nothing;
     return html`
       <header class="${headerClass}">
         <div class="details">
           <h3>${label}</h3>
           <span class="extra-details">${menuDetails}</span>
         </div>
-        ${this.selectedMenuAction}
+        ${actionBlock}
         ${this.closeButton}
       </header>
     `;

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -16,6 +16,7 @@ export class IAMenuSlider extends LitElement {
     return {
       menus: { type: Array },
       open: { type: Boolean },
+      manuallyHandleClose: { type: Boolean },
       selectedMenu: { type: String },
       selectedMenuAction: { type: Object },
       animateMenuOpen: { type: Boolean },

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -17,6 +17,7 @@ export class IAMenuSlider extends LitElement {
       menus: { type: Array },
       open: { type: Boolean },
       selectedMenu: { type: String },
+      selectedMenuAction: { type: Object },
       animateMenuOpen: { type: Boolean },
       manuallyHandleClose: { type: Boolean },
     };
@@ -28,8 +29,17 @@ export class IAMenuSlider extends LitElement {
     this.menus = [];
     this.open = false;
     this.selectedMenu = '';
+    this.selectedMenuAction = nothing;
     this.animateMenuOpen = false;
     this.manuallyHandleClose = false;
+  }
+
+  updated() {
+    const { actionButton } = this.selectedMenuDetails || {};
+    const actionButtonHasChanged = actionButton !== this.selectedMenuAction;
+    if (actionButtonHasChanged) {
+      this.selectedMenuAction = actionButton || nothing;
+    }
   }
 
   /**
@@ -39,6 +49,8 @@ export class IAMenuSlider extends LitElement {
   setSelectedMenu({ detail }) {
     const { id } = detail;
     this.selectedMenu = this.selectedMenu === id ? '' : id;
+    const { actionButton } = this.selectedMenuDetails || {};
+    this.selectedMenuAction = actionButton || nothing;
   }
 
   /**
@@ -56,7 +68,8 @@ export class IAMenuSlider extends LitElement {
   }
 
   get selectedMenuDetails() {
-    return this.menus.find(menu => menu.id === this.selectedMenu);
+    const selectedMenu = this.menus.find(menu => menu.id === this.selectedMenu);
+    return selectedMenu;
   }
 
   get selectedMenuComponent() {
@@ -96,11 +109,8 @@ export class IAMenuSlider extends LitElement {
   }
 
   get renderMenuHeader() {
-    const { label = '', menuDetails = '', actionButton } = this.selectedMenuDetails || {};
-    const actionSection = actionButton
-      ? html`<div class="custom-action">${actionButton}</div>`
-      : nothing;
-    const headerClass = actionButton ? 'with-secondary-action' : '';
+    const { label = '', menuDetails = '' } = this.selectedMenuDetails || {};
+    const headerClass = this.selectedMenuAction ? 'with-secondary-action' : '';
 
     return html`
       <header class="${headerClass}">
@@ -108,7 +118,7 @@ export class IAMenuSlider extends LitElement {
           <h3>${label}</h3>
           <span class="extra-details">${menuDetails}</span>
         </div>
-        ${actionSection}
+        ${this.selectedMenuAction}
         ${this.closeButton}
       </header>
     `;

--- a/test/ia-menu-slider.test.js
+++ b/test/ia-menu-slider.test.js
@@ -146,129 +146,130 @@ describe('<ia-menu-slider>', () => {
 
     expect(el.selectedMenu).to.not.equal(menus[2].id);
   });
-});
 
-describe('Menu list', async () => {
-  const el = await fixture(container(menus));
-  const menuList = el
-    .shadowRoot
-    .querySelectorAll('menu-button');
+  describe('Menu list', async () => {
+    const el = await fixture(container(menus));
+    const menuList = el
+      .shadowRoot
+      .querySelectorAll('menu-button');
 
-  it('shows menu details when available', () => {
-    const firstMenuItem = menuList[0].shadowRoot.querySelector('.menu-details');
-    expect(firstMenuItem.innerText).to.equal(menus[0].menuDetails);
+    it('shows menu details when available', () => {
+      const firstMenuItem = menuList[0].shadowRoot.querySelector('.menu-details');
+      expect(firstMenuItem.innerText).to.equal(menus[0].menuDetails);
 
-    const secondMenuItem = menuList[1].shadowRoot.querySelector('.menu-details');
-    expect(secondMenuItem.innerText).to.be.empty;
-  });
-});
-
-describe('Header section', async () => {
-  let extraButtonClicked = false;
-  const extraActionClickHandler = () => {
-    extraButtonClicked = true;
-  };
-  const menu = {
-    icon: html`<ia-icon icon="audio"></ia-icon>`,
-    title: 'Audio Menu',
-    menuDetails: '(100,000,000 tracks)',
-    actionButton: html`
-      <button
-        style='color: white;'
-        @click=${extraActionClickHandler}
-      >Foo</button>
-    `,
-    label: 'Audio',
-    id: 'audio',
-    component: html`
-      <h1>Menu 2</h1>
-    `,
-  };
-  const el = await fixture(container([menu]));
-
-  // open menu
-  el
-    .shadowRoot
-    .querySelectorAll('menu-button')[0]
-    .shadowRoot
-    .querySelector('button')
-    .click();
-
-  await el.updateComplete;
-  const menuHeader = el.shadowRoot.querySelector('.content header');
-
-  // display
-  it('creates a header section', () => {
-    expect(menuHeader).to.not.be.undefined;
-  });
-  it('adds header title and description', () => {
-    const title = menuHeader.querySelector('h3');
-    expect(title).to.not.be.undefined;
-    expect(title.innerText).to.equal(menu.label);
-
-    const description = menuHeader.querySelector('.extra-details');
-    expect(description).to.not.be.undefined;
-    expect(description.innerText).to.equal(menu.menuDetails);
-  });
-
-  it('has a close button by default', async () => {
-    const closeButton = menuHeader.querySelector('.close');
-    expect(closeButton).to.not.be.undefined;
-  });
-  it('has an option for a menu specific action button', () => {
-    const actionButton = menuHeader.querySelector('.custom-action');
-    expect(actionButton).to.not.be.undefined;
-  });
-
-  // custom action
-  it('can click on the custom action', async () => {
-    const actionButton = menuHeader.querySelector('.custom-action > *');
-    expect(extraButtonClicked).to.be.false; // has not been clicked
-    const actionClick = new MouseEvent('click');
-    actionButton.dispatchEvent(actionClick);
-    await el.updateComplete;
-    expect(extraButtonClicked).to.be.true;
-  });
-
-  // close action
-  it('emits a custom event when the drawer closes', async () => {
-    const closeButton = menuHeader.querySelector('button.close');
-    closeButton.dispatchEvent(new MouseEvent('click'));
-    await el.updateComplete;
-    expect(el.open).to.be.false;
-  });
-
-  describe('Animation toggles for primary open/close state', async () => {
-    const thisMenu = await fixture(container(menus));
-
-    it('does not automatically animate menu', () => {
-      expect(thisMenu.animateMenuOpen).to.be.false;
+      const secondMenuItem = menuList[1].shadowRoot.querySelector('.menu-details');
+      expect(secondMenuItem.innerText).to.be.empty;
     });
+  });
 
-    it('uses `animate` class to power transition when turned on', async () => {
-      thisMenu.animateMenuOpen = true;
+  describe('Header section', () => {
+    let extraButtonClicked = false;
+    const extraActionClickHandler = () => {
+      extraButtonClicked = true;
+    };
+    const menu = {
+      icon: html`<ia-icon icon="audio"></ia-icon>`,
+      title: 'Audio Menu',
+      menuDetails: '(100,000,000 tracks)',
+      actionButton: html`
+        <button
+          id="custom-action-button"
+          style='color: white;'
+          @click=${extraActionClickHandler}
+        >Foo</button>
+      `,
+      label: 'Audio',
+      id: 'audio',
+      component: html`
+        <h1>Menu 2</h1>
+      `,
+    };
+
+    it('creates a header section', async () => {
+      const el = await fixture(container([menu]));
+      el
+        .shadowRoot
+        .querySelectorAll('menu-button')[0]
+        .shadowRoot
+        .querySelector('button')
+        .click();
       await el.updateComplete;
 
-      expect(thisMenu.shadowRoot.querySelector('.menu.animate').classList.contains('animate')).to.be.true;
+      const menuHeader = el.shadowRoot.querySelector('.content header');
+      expect(menuHeader).to.not.be.undefined;
+
+      const title = menuHeader.querySelector('h3');
+      expect(title).to.not.be.undefined;
+      expect(title.innerText).to.equal(menu.label);
+
+      const description = menuHeader.querySelector('.extra-details');
+      expect(description).to.not.be.undefined;
+      expect(description.innerText).to.equal(menu.menuDetails);
+
+      const closeButton = menuHeader.querySelector('.close');
+      expect(closeButton).to.not.be.undefined;
+
+      const actionButton = menuHeader.querySelector('.custom-action');
+      expect(actionButton).to.not.be.undefined;
+    });
+
+    it('can click on the custom action', async () => {
+      const el = await fixture(container([menu]));
+      el
+        .shadowRoot
+        .querySelectorAll('menu-button')[0]
+        .shadowRoot
+        .querySelector('button')
+        .click();
+      await el.updateComplete;
+
+      const menuHeader = el.shadowRoot.querySelector('.content header');
+      const actionButton = menuHeader.querySelector('.custom-action > *');
+      expect(el.selectedMenuAction).to.not.be.undefined;
+      expect(extraButtonClicked).to.be.false; // has not been clicked
+
+      const actionClick = new MouseEvent('click');
+      actionButton.dispatchEvent(actionClick);
+      await el.updateComplete;
+      expect(extraButtonClicked).to.be.true;
     });
   });
 
-  describe('Menu close behavior', async () => {
-    const thisMenu = await fixture(container(menus));
+  describe('Close behavior', () => {
+    it('emits a custom event when the drawer closes', async () => {
+      const el = await fixture(container(menus));
+      el.open = true;
+      await el.updateComplete;
+      expect(el.open).to.be.true;
 
-    it('has property: `manuallyHandleClose`', () => {
-      expect(thisMenu.manuallyHandleClose).to.exist;
+      const menuHeader = el.shadowRoot.querySelector('.content header');
+      const closeButton = menuHeader.querySelector('button.close');
+      closeButton.dispatchEvent(new MouseEvent('click'));
+      await el.updateComplete;
+      expect(el.open).to.be.false;
     });
+    it('emits event but does not close drawer if prop `manuallyHandleClose = true`', async () => {
+      let sliderEmittedEvent = false;
+      const el = await fixture(container(menus));
+      el.manuallyHandleClose = true;
+      el.open = true;
+      await el.updateComplete;
 
-    thisMenu.manuallyHandleClose = true;
-    thisMenu.open = true;
-    const closebutton = thisMenu.shadowRoot.querySelector('button.close');
-    closebutton.click();
-    await el.updateComplete;
-    closebutton;
-    it('does not manually close menu when property is set: `manuallyHandleClose`', () => {
-      expect(thisMenu.manuallyHandleClose).to.be.true;
-      expect(thisMenu.open).to.be.true;
+      // confirm base config
+      expect(el.open).to.be.true;
+      expect(sliderEmittedEvent).to.be.false;
+
+      el.addEventListener('menuSliderClosed', () => {
+        sliderEmittedEvent = true;
+      });
+
+      const menuHeader = el.shadowRoot.querySelector('.content header');
+      const closeButton = menuHeader.querySelector('button.close');
+      closeButton.dispatchEvent(new MouseEvent('click'));
+      await el.updateComplete;
+
+      expect(sliderEmittedEvent).to.be.true; // handler received click event
+      expect(el.open).to.be.true; // open state is still active, does not close
     });
   });
 });


### PR DESCRIPTION
Changes in PR:
- pins optional header action button to a property so it will reflect freshest incoming element
- formally adds property `manuallyCloseHeader` (was already being used in PB) + unit tests
- update unit tests so that a group of them are working again (TLDR: no `async` in describe callback)
- demo updates:
  - side menu opens to 320px - item nav size
  - show changing header action button on click (prep for multiple files sorting action)
  
To Test:
- pull branch down, run `npm install && npm run start`
- menu can toggle open & close
- open 1st menu "Audio" -> note the optional action button on header -> click -> color changes
- you can go [here](https://github.com/internetarchive/bookreader/pull/787): go to demo page - item nav side menu toggles open & close https://deploy-preview-787--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala 
  
![ezgif com-video-to-gif-8](https://user-images.githubusercontent.com/7840857/120392228-0d37eb80-c2e5-11eb-9094-005371492b3a.gif)



