### PR TITLE
WIP: Lit2 upgrade

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,8 @@
       --iconFillColor: #fff;
       --iconStrokeColor: #fff;
       --activeButtonBg: #282828;
+      --iconWidth: 24px;
+      --iconHeight: 24px;
     }
 
     html {
@@ -59,9 +61,9 @@
   </main>
 
   <script type="module">
-    /* eslint-disable max-classes-per-file, import/no-extraneous-dependencies, no-console */
-    import { render } from 'lit-html';
-    import { html, css, LitElement } from 'lit-element';
+    /* eslint-disable max-classes-per-file, import/no-extraneous-dependencies, no-console, no-use-before-define, class-methods-use-this */
+    import { render } from 'lit/html.js';
+    import { html, css, LitElement } from 'lit';
     import IAIcons from '@internetarchive/ia-icons';
     import '@internetarchive/icon-volumes/icon-volumes.js';
     import '../ia-menu-slider.js';
@@ -225,12 +227,13 @@
         console.log('Drawer Closed', event);
         menuOpen = false;
       };
+      const animateMenu = true;
       const menuSliderElement = html`
         <ia-menu-slider
           .menus=${menus}
           @animateMenuOpen=${closeCB}
           ?open=${menuOpen}
-          ?animateMenuOpen=${true}
+          ?animateMenuOpen=${animateMenu}
         ></ia-menu-slider>`;
 
       const toggleMenu = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@internetarchive/icon-collapse-sidebar": "^1.1.0",
-        "lit-element": "^2.2.1",
-        "lit-html": "^1.1.2"
+        "@internetarchive/icon-collapse-sidebar": "^1.3.2",
+        "lit": "^2.1.4"
       },
       "devDependencies": {
-        "@internetarchive/ia-icons": "0.3.0",
-        "@internetarchive/icon-volumes": "^1.1.0",
+        "@internetarchive/ia-icons": "^1.3.2",
+        "@internetarchive/icon-volumes": "^1.3.2",
         "@open-wc/demoing-storybook": "^2.0.0",
         "@open-wc/eslint-config": "^2.0.0",
         "@open-wc/testing": "^2.0.0",
@@ -1299,169 +1298,442 @@
       }
     },
     "node_modules/@internetarchive/ia-icons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-0.3.0.tgz",
-      "integrity": "sha512-wNYV3oNxpMJIiINVo4kFt5N7FnW/C9YZ1rp1Mxtul8U4RpbXgYcGKJlbDV8MikLjEAnktQCJkR9GBPtbcMoYbA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-1.3.2.tgz",
+      "integrity": "sha512-l5nSwTCYUYHpkinlvd1V5qpO5yJ5M9DDTjXjIf/xX/HsaMECFYNKom/pzXkhar1StXhP4Azv9D8SxnmIIQliHQ==",
       "dev": true,
       "dependencies": {
-        "@internetarchive/icon-advance": "^0.3.0",
-        "@internetarchive/icon-audio": "^0.3.0",
-        "@internetarchive/icon-close": "^0.3.0",
-        "@internetarchive/icon-donate": "^0.3.0",
-        "@internetarchive/icon-ellipses": "^0.3.0",
-        "@internetarchive/icon-ia-logo": "^0.3.0",
-        "@internetarchive/icon-images": "^0.3.0",
-        "@internetarchive/icon-search": "^0.3.0",
-        "@internetarchive/icon-software": "^0.3.0",
-        "@internetarchive/icon-texts": "^0.3.0",
-        "@internetarchive/icon-upload": "^0.3.0",
-        "@internetarchive/icon-user": "^0.3.0",
-        "@internetarchive/icon-video": "^0.3.0",
-        "@internetarchive/icon-web": "^0.3.0",
-        "lit-element": "^2.2.1"
-      }
-    },
-    "node_modules/@internetarchive/ia-icons/node_modules/@internetarchive/icon-audio": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-audio/-/icon-audio-0.3.2.tgz",
-      "integrity": "sha512-AfmQN+WByVh9jQODmz3+ocAZKtcIsrY8zw3L4ix+5+ZUmOCH7KzzjVZ6Fz7WO8h4eMlfwM74kPLqT93Kx7vHrw==",
-      "dev": true,
-      "dependencies": {
-        "lit-html": "^1.2.1"
-      }
-    },
-    "node_modules/@internetarchive/ia-icons/node_modules/@internetarchive/icon-donate": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-donate/-/icon-donate-0.3.2.tgz",
-      "integrity": "sha512-N+Rf5Ax7zRWU/ueBnmqm5UjTQv3jbq9A7InXT5QSI6Vw/LdRQiBOqWND41anrn3rMAQ9YxDiMA5dvEaAp8ds3A==",
-      "dev": true,
-      "dependencies": {
-        "lit-html": "^1.2.1"
-      }
-    },
-    "node_modules/@internetarchive/ia-icons/node_modules/@internetarchive/icon-software": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-software/-/icon-software-0.3.2.tgz",
-      "integrity": "sha512-kB6kEBcJ5Qqz2Y96dtVzApsLHWIeDg11rv7ClgfuBr6xm8+9F4RAU1+xfs1tEFkSjmLqM83REzBHKns4wDqBng==",
-      "dev": true,
-      "dependencies": {
-        "lit-html": "^1.2.1"
+        "@internetarchive/ia-icons": "^1.3.2",
+        "@internetarchive/icon-advance": "^1.3.2",
+        "@internetarchive/icon-applepay": "^1.3.2",
+        "@internetarchive/icon-audio": "^1.3.2",
+        "@internetarchive/icon-bookmark": "^1.3.2",
+        "@internetarchive/icon-calendar": "^1.3.2",
+        "@internetarchive/icon-calendar-blank": "^1.3.2",
+        "@internetarchive/icon-close": "^1.3.2",
+        "@internetarchive/icon-close-circle": "^1.3.2",
+        "@internetarchive/icon-collapse-sidebar": "^1.3.2",
+        "@internetarchive/icon-credit-card": "^1.3.2",
+        "@internetarchive/icon-dl": "^1.3.2",
+        "@internetarchive/icon-donate": "^1.3.2",
+        "@internetarchive/icon-edit-pencil": "^1.3.2",
+        "@internetarchive/icon-ellipses": "^1.3.2",
+        "@internetarchive/icon-email": "^1.3.2",
+        "@internetarchive/icon-facebook": "^1.3.2",
+        "@internetarchive/icon-googlepay": "^1.3.2",
+        "@internetarchive/icon-ia-logo": "^1.3.2",
+        "@internetarchive/icon-images": "^1.3.2",
+        "@internetarchive/icon-info": "^1.3.2",
+        "@internetarchive/icon-link": "^1.3.2",
+        "@internetarchive/icon-locale-pin": "^1.3.2",
+        "@internetarchive/icon-lock": "^1.3.2",
+        "@internetarchive/icon-magnify-minus": "^1.3.2",
+        "@internetarchive/icon-magnify-plus": "^1.3.2",
+        "@internetarchive/icon-paypal": "^1.3.2",
+        "@internetarchive/icon-pinterest": "^1.3.2",
+        "@internetarchive/icon-search": "^1.3.2",
+        "@internetarchive/icon-share": "^1.3.2",
+        "@internetarchive/icon-software": "^1.3.2",
+        "@internetarchive/icon-sort-ascending": "^1.3.2",
+        "@internetarchive/icon-sort-descending": "^1.3.2",
+        "@internetarchive/icon-texts": "^1.3.2",
+        "@internetarchive/icon-toc": "^1.3.2",
+        "@internetarchive/icon-tumblr": "^1.3.2",
+        "@internetarchive/icon-twitter": "^1.3.2",
+        "@internetarchive/icon-upload": "^1.3.2",
+        "@internetarchive/icon-user": "^1.3.2",
+        "@internetarchive/icon-venmo": "^1.3.2",
+        "@internetarchive/icon-video": "^1.3.2",
+        "@internetarchive/icon-visual-adjustment": "^1.3.2",
+        "@internetarchive/icon-volumes": "^1.3.2",
+        "@internetarchive/icon-web": "^1.3.2",
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-advance": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-advance/-/icon-advance-0.3.2.tgz",
-      "integrity": "sha512-sKilVmp048lOitFE/q8yaM/iwBpPbFSLFVw/BeUv3b7N+s1nK0GWDu58A3ipZdGCwyCj4lq+a8YBAn4Ymd8Snw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-advance/-/icon-advance-1.3.2.tgz",
+      "integrity": "sha512-5HaQZz3JU499KXf6S5bh01Sx7oIfRkgp8vzfFkwGoNYFG90molpesEGasV7bthJ/CR2kP2fUBvlN+s3ZTCzseQ==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-applepay": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-applepay/-/icon-applepay-1.3.2.tgz",
+      "integrity": "sha512-LNVEfjP+UuZMUGDtskPejsaCxhqhUv8+0hemAoFh5R8qW9S22gTADwWgf0DasoxEH3NFNHx7kDvxRjTTBeCAfg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-audio": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-audio/-/icon-audio-1.3.2.tgz",
+      "integrity": "sha512-5QWOFJNqK2Kf9jIyHyqaKw7Y3dwps+Wzfl+DfkfqvQrQfNpVe3sVdrpLHQSZ0f6G8ugcZQUvpblZpOh3lJqVwg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-bookmark": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-bookmark/-/icon-bookmark-1.3.2.tgz",
+      "integrity": "sha512-Q/8lSub0TxXkcKn55JfAjjLSzSZxcMFuZW6qgRmxKtawxx6ydBqV8ZJ0+Rg7tUpDU9AeSjOLOGivu/1h9CXXWA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-calendar": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-calendar/-/icon-calendar-1.3.2.tgz",
+      "integrity": "sha512-RT+uNtT2662XnuuLnTo5mlAWXRQkYu3fXQK+BPNyhIi52QWhvD11Ukts1eXJIaydgOfDjOEZm8mmWHw/4//IAw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-calendar-blank": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-calendar-blank/-/icon-calendar-blank-1.3.2.tgz",
+      "integrity": "sha512-4xu/V7j6IvJH/QRPd7Bumw85lRt+YnDqS/EotgiEDLX55BwVxFtKTbxle6NMAvsy4W+s6dhgzGZEcPGi3p4dpA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-close": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-0.3.2.tgz",
-      "integrity": "sha512-z3Z/Jl9qi1etI6Tt7nQnRk73grlIdWoYnMxX5trgH/9szZMUH6ofgUxR1vFTlqeTwswGWBX0vq3fYdTm+m2g7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-1.3.2.tgz",
+      "integrity": "sha512-4QhM/MDC1IsWQZoE3lt7A4l3/VOopJta+xVnDLqsbA3OW2sT+ilm/mUiP4l4Lm/NzdbQQwhnQMOZPcQvllxkzA==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-close-circle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close-circle/-/icon-close-circle-1.3.2.tgz",
+      "integrity": "sha512-xx1xtn99EuCV3l2eriuwzw27uvhXraS+mboIvaR7pArvGOKCeD4y9EEp0/QnBxVlNCOnz2dnWV3j9jnM+q1H0Q==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-collapse-sidebar": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-collapse-sidebar/-/icon-collapse-sidebar-1.1.0.tgz",
-      "integrity": "sha512-0P6NCdPsXBShnOXTwtc/+zpv27ibBVr/NnwNIVMIYfip89GCeQu7F60cNXuzDqZPhLsJKIymykT6ewJaFJ6Olw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-collapse-sidebar/-/icon-collapse-sidebar-1.3.2.tgz",
+      "integrity": "sha512-IMHMRMZsk7IssQHQz4VEZp+Md5pQVLXaFgcnFWcnWUOfVE7a9NKewckbpYG84vFCvhNT/v49uzid+SWlGLeYcA==",
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-credit-card": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-credit-card/-/icon-credit-card-1.3.2.tgz",
+      "integrity": "sha512-/CLBvqmtWN1a13JtjDdSGt461ukZdrzb+Ch6Hkg4T4AnqTSbucl3+3C5sBmNhjIisJGzEI2nxNIQHIlIu+WoIg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-dl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-dl/-/icon-dl-1.3.2.tgz",
+      "integrity": "sha512-QpvZzHzJdozMGAi1pPA/h9p6tEroIhdY9jJ70w0O0uCAo8d3zVetdYgJt1DGEpvOdP3Bp8now0MulKCz01n5lw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-donate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-donate/-/icon-donate-1.3.2.tgz",
+      "integrity": "sha512-vmyDImVpgcl5dxuqvdhcM4mZNQmHa+LSWKDcXlpEoiE8PZMtGAM4NNCz/mjp0E1lCvPQPckg63/hZ+hUkJdjQA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-edit-pencil": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-edit-pencil/-/icon-edit-pencil-1.3.2.tgz",
+      "integrity": "sha512-UfQsMCuuJqbdtSjcuOcMgbM52nfDKug+KajwOrea4QdKMS2pK6RAfOwGJ9geMFuXUs3NbJ4vmNq4R2LaghyDdQ==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-ellipses": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ellipses/-/icon-ellipses-0.3.2.tgz",
-      "integrity": "sha512-ohxkQZXfny/Ftwu4MIP7szrXA4H5/lDVZNXJ85LP9mjllfs20sF5bWGMAsO44GMiugQNbxZZhLgmcmxpz478jg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ellipses/-/icon-ellipses-1.3.2.tgz",
+      "integrity": "sha512-VcNbuWBqqRChVzjLb1qTwZdzVyN9fZF/kRcrR+f+mTzdbRUqyTwkN89//q+je+enHapNelAYwkX9tFr+GhnO8g==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-email": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-email/-/icon-email-1.3.2.tgz",
+      "integrity": "sha512-VzJ1Qsoal19+rZqEcwbsSzhFpV1Fn51hw2Qiq4pa7KAU6QzDMzJVkcvCK7bBOxLoVe3HwaeSMzKEXxr5h+VBfw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-facebook": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-facebook/-/icon-facebook-1.3.2.tgz",
+      "integrity": "sha512-sTBbBlya8jApRxhfFiNWKXmOiVQ6xCzz00tSJ5Puh7EIRQQhOEFgxmn8sCAIqmEN0fSnuFRElbERqsGrLBoxtw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-googlepay": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-googlepay/-/icon-googlepay-1.3.2.tgz",
+      "integrity": "sha512-lKEqkboTNIVNStpdkSaZUbA8MndC/c7+aACu5RAQjHo2i0IUwb5EzuUZkt86PMoXswJe+HtCHowFVkirFZ427w==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-ia-logo": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ia-logo/-/icon-ia-logo-0.3.2.tgz",
-      "integrity": "sha512-62D4i7toT/fCFRIVuhJTMXyMKUwO2ax0AvaQVuOnAjvbDGIjepl3fRUL3qfi7ArWPylYTDf9KY3g68rmYwkIJQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ia-logo/-/icon-ia-logo-1.3.2.tgz",
+      "integrity": "sha512-lDZdaqj7A6nv5dJPaes6UZwDqlr3yMgaKJZSuMTqMUpjaZ0bcfDIoDFO4y2YjQ2uUHoRIgRNqyZVMSNJMowXzQ==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-images": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-images/-/icon-images-0.3.2.tgz",
-      "integrity": "sha512-hfqlzctiLvLCrxp+1MZLI8Bnk4WWD54VMD5QPa+t7uBdJuGfceXeSkxuTEwGDW6/bM4wXzhu/XaH+LL7Y5VimA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-images/-/icon-images-1.3.2.tgz",
+      "integrity": "sha512-VkqvoaVKiaEhYUx7O2nyG2qoa4YLQtTQXmmuE3G7JEUm6sxo02/hVYCeS/5EpsfaHkSn9xtTysSWghaic3QSSg==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-info": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-info/-/icon-info-1.3.2.tgz",
+      "integrity": "sha512-drkJWwFV4S9AH+/vkh8O5k+XclWxTqZoo/ELwt5dEsf7YiZKr5z80IetEZN5JeYh4OqoJJQfIJ81ZnjxJMlVzw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-link": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-link/-/icon-link-1.3.2.tgz",
+      "integrity": "sha512-NOZBXX1bXrAcNnBEPG0bdh8JcsQFdR3xf2VYJ9FeXLkCiJFXI3NaB/LG7ggkx2P4V10kC67hr52DX8MIDvZbtg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-locale-pin": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-locale-pin/-/icon-locale-pin-1.3.2.tgz",
+      "integrity": "sha512-wwsGwLMk5JMzEjgIvUwdZZo9Y8OKkvr0LuX3DVcaP/3t6XPTZngScst3NzcOav5+JHaAvKucRK8mI8tThSPZ9Q==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-lock": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-lock/-/icon-lock-1.3.2.tgz",
+      "integrity": "sha512-OwD0HC6SSIwN+oG0fmHM+desP7Pxw7X2bVoE55xHK4oA10l55DtMnbxzHb/HKVDltNvk9YaIV7/T+HgTa2heHA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-magnify-minus": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-minus/-/icon-magnify-minus-1.3.2.tgz",
+      "integrity": "sha512-Hb4d/phIcpgSon9NjAJ0hf1gVePLOMVx+H82M0yswLluJ4zuBGIpKD3hyDXmfsPS9/LW4SVczACuIw8DPocZ3A==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-magnify-plus": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-plus/-/icon-magnify-plus-1.3.2.tgz",
+      "integrity": "sha512-DBFrpdLhxFr0eXkszkeJqGBZIK8xApzfPUy9fmzTKvfq/z+N2E662Gqp8QXYg9VSP8uVW5YBS5rkRPVuuGRQ6g==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-paypal": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-paypal/-/icon-paypal-1.3.2.tgz",
+      "integrity": "sha512-X4IFJw/sSUjXV7OMqnftfkY1i22UvdgctUgf7/R4v7eJO4mhGQnwtH6DkBXzKbAt+FL9f1RhI1Wmz6WrxH19HQ==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-pinterest": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-pinterest/-/icon-pinterest-1.3.2.tgz",
+      "integrity": "sha512-UPmePtbTqqIK/uCqO5UZeFEgKOjKM6SxlUJCK6xAUAtUeSUv7dq4UywthNC8W5WfXvZGxGtAwioYt5Pddn43PQ==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-search": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-search/-/icon-search-0.3.2.tgz",
-      "integrity": "sha512-8hT8h1IZ3R32bdVlY+H5LHgvnr1BsOeckVH36QUmkiSfCdGC5MZ1KebVzEJle5EsME1bu/d18Za8oT/y/4ocLA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-search/-/icon-search-1.3.2.tgz",
+      "integrity": "sha512-L8pK/Om4oU6+n24Cm2GxYjEIyZzhJzXfSg2shnoNnzUt1WnjDsMGYgXEmjsx4Vq4DG6caTq7FZ5AOfxQ1Z2zIw==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-share": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.3.2.tgz",
+      "integrity": "sha512-XwMcznii1yW/f8lEHBQe974GKGsvgeter7AkXHPK3Fi2o2Jm7IDmT71zhb49mKKp66Vjr3lLgPWzPld+wZgnEA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-software": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-software/-/icon-software-1.3.2.tgz",
+      "integrity": "sha512-l/LAXCy8Gly/q32x0j6bmlNYbVIwicd6yrD83c+9cSCH4noHqZesFbm7TwunM6GXl8DpwCK6230ag01thxVkXQ==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-sort-ascending": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-ascending/-/icon-sort-ascending-1.3.2.tgz",
+      "integrity": "sha512-JibI67dO9pXJOBPBhLOUFrfngv7cFmM/U+2SmmADb9PsZ/VpMj1O60u/zxURhmF8XFzsLi0lpOKxizKoVGHFEg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-sort-descending": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-descending/-/icon-sort-descending-1.3.2.tgz",
+      "integrity": "sha512-ekMXJG8hwgtFCw7GRf00zW3rL/tXh1vWt/Je1RqdE4cudZCltiSwDizmHC2iVOL/Uz/DuuS2e3zK8448lzrrXw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-texts": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-texts/-/icon-texts-0.3.2.tgz",
-      "integrity": "sha512-r/8JIxtnRaAAT+k7zzcuAzklriilTSvApw0x/glbfrxhKlo+DF+9XKMnp0blR3bktJtSUJGY9O7MuFOxyz9HBQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-texts/-/icon-texts-1.3.2.tgz",
+      "integrity": "sha512-UBecBgGcCB894SaLTOvUbB5ayBRh+wOqrqwkdput0fHJTGZcMVgk04dZpHvShZq5nz2pGRzDK1ig1nwOzLhYnQ==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-toc": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-toc/-/icon-toc-1.3.2.tgz",
+      "integrity": "sha512-KYk5duzWsfS0bOKYN/jtMkKEOh2YhtmAdVT2RHc/oEh+5Pwa8Ujx0sp+x6NRUsbROwi2eJr8ui067memzFzWPw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-tumblr": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-tumblr/-/icon-tumblr-1.3.2.tgz",
+      "integrity": "sha512-IAFNpheZ2HujatnLC5Q70WdoIboJlMy8IkENOEZfTW/TfGiX0sdDkhEsOkI8wR5YDOX6C0R/LNPnUot5zjInaw==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-twitter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-twitter/-/icon-twitter-1.3.2.tgz",
+      "integrity": "sha512-aL1dizdh+LwOkE/6we7ZB/mXPN+4Hp/FsSDohI05X/NVu6c8nL5IeH2+BI6WS/knPUehBvh7lwGUzRFRwtqzCA==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-upload": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-upload/-/icon-upload-0.3.2.tgz",
-      "integrity": "sha512-a8w+TSvYT10HyV1DJiN45HcKW/jPysnYDyq+f4scN+c1F9XvwM1067HtKMcKP00zC3pwggs9BjpySRNtxu+WoA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-upload/-/icon-upload-1.3.2.tgz",
+      "integrity": "sha512-QdXk4PqeyYNjAI8Bey/cswEvcSPshQzTn5QMoWd0GZkaZ+fzuBwc9fmkc+tefcXcDd86D17MZZ7uudE4DnJENQ==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-user": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-user/-/icon-user-0.3.2.tgz",
-      "integrity": "sha512-z0fHHYAQZP2sDK/xht6xU6OteysvDxU36Mv8PmjWUI+5lrpucZVvgdNzzLlDXUAMsRsWkvnfGqieiqbhDpwOmQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-user/-/icon-user-1.3.2.tgz",
+      "integrity": "sha512-A5fCby40AEWWbrSSgGzhcSVDfL9M+S/Zl1oPTid/+mBuZPik0KPS5xoMBkT/952/ujbnLLR9URemzfPdSeBx+Q==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-venmo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-venmo/-/icon-venmo-1.3.2.tgz",
+      "integrity": "sha512-/gJ+/UpdBkqjo9L9zRL2BzUmHihcNCTyGybI8JShCPV0cW4NFIX9dr37cB70UuZpKdQZ5JsiJda0W8mPgO98aQ==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-video": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-video/-/icon-video-0.3.2.tgz",
-      "integrity": "sha512-lcJ6ggyJtd7Wbe9ZuTAUhbSQKDIatAi4tL4A2sYvqJtZzqm7C/+CMNr6uadgPOsY61DSFrpF7QrvNuBWOOyjvg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-video/-/icon-video-1.3.2.tgz",
+      "integrity": "sha512-wo1Cz6+4vLoGVAkhpscafBO8klr+YJsqSVGu7GbC4SWcJ1PcgcPJdpofMOHbDuTCbysc9QA5I+CENvnPHlsrcg==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-visual-adjustment": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-visual-adjustment/-/icon-visual-adjustment-1.3.2.tgz",
+      "integrity": "sha512-eqnHimIaDJ3SfFGChg+43H1jjW4XEsbMYHrgXOLFUR/0PtUIFkb0Mvv39YUD64B7uqQZTFbLvyabmxrQQYFQLg==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-volumes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-volumes/-/icon-volumes-1.1.0.tgz",
-      "integrity": "sha512-wBVzs6TxG7CGRth6yQ3DqWE2LJnZaA+AhiQ/dJEevtmHDV7pRIib5VbYlpd64gWGU5fcAxamfLSVQArwVoOEeQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-volumes/-/icon-volumes-1.3.2.tgz",
+      "integrity": "sha512-Hi7P1FXae4USSaF4eQYPTz5fZfvIBjRCm7Li0IgGz0vmsJGVA5aRgwcQHvcjsSuLfEJP6lJ9skRd6srSWe08fg==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@internetarchive/icon-web": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-web/-/icon-web-0.3.2.tgz",
-      "integrity": "sha512-qLBWwFE3xwik+RDB+p0LowGaY6AcuO/X+2SPN1pqvCE+68O7J9sLsg9gUagG5olcIant82VpRLHSjD1WfZ//iA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-web/-/icon-web-1.3.2.tgz",
+      "integrity": "sha512-WWHcPKRud2ZWZTvxSgqLbugkSuSgXypxiMU864P6dreNGZMwVoGnkke6/1Zc73hMy3XIqdEWtLUEQsbbagc1Rw==",
       "dev": true,
       "dependencies": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@koa/cors": {
@@ -1475,6 +1747,11 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.3.tgz",
+      "integrity": "sha512-fu0HW3VpeQdTx2BxjcMD0pEXB6M3xYi7Cgmqr7+jtyN7hNZJGFWqqQFfyJRwP8cBGQz3WW1txBiPPf9dK2xdUg=="
     },
     "node_modules/@mdjs/core": {
       "version": "0.3.3",
@@ -2605,6 +2882,11 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "node_modules/@types/uglify-js": {
       "version": "3.9.3",
@@ -8868,10 +9150,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/lit": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.4.tgz",
+      "integrity": "sha512-m1tHAZdXQhiBe0ReAjyVIUeKnHZpBfx+A5R5dkia8dtvIBwOR6KhD+RxaDnCwrEavRqkZAy5ntLv7chiOZCdNg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.1.0",
+        "lit-element": "^3.1.0",
+        "lit-html": "^2.1.0"
+      }
+    },
     "node_modules/lit-element": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
       "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "dev": true,
       "dependencies": {
         "lit-html": "^1.1.1"
       }
@@ -8879,7 +9172,25 @@
     "node_modules/lit-html": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==",
+      "dev": true
+    },
+    "node_modules/lit/node_modules/lit-element": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.2.tgz",
+      "integrity": "sha512-5VLn5a7anAFH7oz6d7TRG3KiTZQ5GEFsAgOKB8Yc+HDyuDUGOT2cL1CYTz/U4b/xlJxO+euP14pyji+z3Z3kOg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.1.0",
+        "lit-html": "^2.1.0"
+      }
+    },
+    "node_modules/lit/node_modules/lit-html": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.3.tgz",
+      "integrity": "sha512-WgvdwiNeuoT0mYEEJI+AAV2DEtlqzVM4lyDSaeQSg5ZwhS/CkGJBO/4n66alApEuSS9WXw9+ADBp8SPvtDEKSg==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
@@ -15637,171 +15948,442 @@
       }
     },
     "@internetarchive/ia-icons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-0.3.0.tgz",
-      "integrity": "sha512-wNYV3oNxpMJIiINVo4kFt5N7FnW/C9YZ1rp1Mxtul8U4RpbXgYcGKJlbDV8MikLjEAnktQCJkR9GBPtbcMoYbA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-1.3.2.tgz",
+      "integrity": "sha512-l5nSwTCYUYHpkinlvd1V5qpO5yJ5M9DDTjXjIf/xX/HsaMECFYNKom/pzXkhar1StXhP4Azv9D8SxnmIIQliHQ==",
       "dev": true,
       "requires": {
-        "@internetarchive/icon-advance": "^0.3.0",
-        "@internetarchive/icon-audio": "^0.3.0",
-        "@internetarchive/icon-close": "^0.3.0",
-        "@internetarchive/icon-donate": "^0.3.0",
-        "@internetarchive/icon-ellipses": "^0.3.0",
-        "@internetarchive/icon-ia-logo": "^0.3.0",
-        "@internetarchive/icon-images": "^0.3.0",
-        "@internetarchive/icon-search": "^0.3.0",
-        "@internetarchive/icon-software": "^0.3.0",
-        "@internetarchive/icon-texts": "^0.3.0",
-        "@internetarchive/icon-upload": "^0.3.0",
-        "@internetarchive/icon-user": "^0.3.0",
-        "@internetarchive/icon-video": "^0.3.0",
-        "@internetarchive/icon-web": "^0.3.0",
-        "lit-element": "^2.2.1"
-      },
-      "dependencies": {
-        "@internetarchive/icon-audio": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@internetarchive/icon-audio/-/icon-audio-0.3.2.tgz",
-          "integrity": "sha512-AfmQN+WByVh9jQODmz3+ocAZKtcIsrY8zw3L4ix+5+ZUmOCH7KzzjVZ6Fz7WO8h4eMlfwM74kPLqT93Kx7vHrw==",
-          "dev": true,
-          "requires": {
-            "lit-html": "^1.2.1"
-          }
-        },
-        "@internetarchive/icon-donate": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@internetarchive/icon-donate/-/icon-donate-0.3.2.tgz",
-          "integrity": "sha512-N+Rf5Ax7zRWU/ueBnmqm5UjTQv3jbq9A7InXT5QSI6Vw/LdRQiBOqWND41anrn3rMAQ9YxDiMA5dvEaAp8ds3A==",
-          "dev": true,
-          "requires": {
-            "lit-html": "^1.2.1"
-          }
-        },
-        "@internetarchive/icon-software": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@internetarchive/icon-software/-/icon-software-0.3.2.tgz",
-          "integrity": "sha512-kB6kEBcJ5Qqz2Y96dtVzApsLHWIeDg11rv7ClgfuBr6xm8+9F4RAU1+xfs1tEFkSjmLqM83REzBHKns4wDqBng==",
-          "dev": true,
-          "requires": {
-            "lit-html": "^1.2.1"
-          }
-        }
+        "@internetarchive/ia-icons": "^1.3.2",
+        "@internetarchive/icon-advance": "^1.3.2",
+        "@internetarchive/icon-applepay": "^1.3.2",
+        "@internetarchive/icon-audio": "^1.3.2",
+        "@internetarchive/icon-bookmark": "^1.3.2",
+        "@internetarchive/icon-calendar": "^1.3.2",
+        "@internetarchive/icon-calendar-blank": "^1.3.2",
+        "@internetarchive/icon-close": "^1.3.2",
+        "@internetarchive/icon-close-circle": "^1.3.2",
+        "@internetarchive/icon-collapse-sidebar": "^1.3.2",
+        "@internetarchive/icon-credit-card": "^1.3.2",
+        "@internetarchive/icon-dl": "^1.3.2",
+        "@internetarchive/icon-donate": "^1.3.2",
+        "@internetarchive/icon-edit-pencil": "^1.3.2",
+        "@internetarchive/icon-ellipses": "^1.3.2",
+        "@internetarchive/icon-email": "^1.3.2",
+        "@internetarchive/icon-facebook": "^1.3.2",
+        "@internetarchive/icon-googlepay": "^1.3.2",
+        "@internetarchive/icon-ia-logo": "^1.3.2",
+        "@internetarchive/icon-images": "^1.3.2",
+        "@internetarchive/icon-info": "^1.3.2",
+        "@internetarchive/icon-link": "^1.3.2",
+        "@internetarchive/icon-locale-pin": "^1.3.2",
+        "@internetarchive/icon-lock": "^1.3.2",
+        "@internetarchive/icon-magnify-minus": "^1.3.2",
+        "@internetarchive/icon-magnify-plus": "^1.3.2",
+        "@internetarchive/icon-paypal": "^1.3.2",
+        "@internetarchive/icon-pinterest": "^1.3.2",
+        "@internetarchive/icon-search": "^1.3.2",
+        "@internetarchive/icon-share": "^1.3.2",
+        "@internetarchive/icon-software": "^1.3.2",
+        "@internetarchive/icon-sort-ascending": "^1.3.2",
+        "@internetarchive/icon-sort-descending": "^1.3.2",
+        "@internetarchive/icon-texts": "^1.3.2",
+        "@internetarchive/icon-toc": "^1.3.2",
+        "@internetarchive/icon-tumblr": "^1.3.2",
+        "@internetarchive/icon-twitter": "^1.3.2",
+        "@internetarchive/icon-upload": "^1.3.2",
+        "@internetarchive/icon-user": "^1.3.2",
+        "@internetarchive/icon-venmo": "^1.3.2",
+        "@internetarchive/icon-video": "^1.3.2",
+        "@internetarchive/icon-visual-adjustment": "^1.3.2",
+        "@internetarchive/icon-volumes": "^1.3.2",
+        "@internetarchive/icon-web": "^1.3.2",
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-advance": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-advance/-/icon-advance-0.3.2.tgz",
-      "integrity": "sha512-sKilVmp048lOitFE/q8yaM/iwBpPbFSLFVw/BeUv3b7N+s1nK0GWDu58A3ipZdGCwyCj4lq+a8YBAn4Ymd8Snw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-advance/-/icon-advance-1.3.2.tgz",
+      "integrity": "sha512-5HaQZz3JU499KXf6S5bh01Sx7oIfRkgp8vzfFkwGoNYFG90molpesEGasV7bthJ/CR2kP2fUBvlN+s3ZTCzseQ==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-applepay": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-applepay/-/icon-applepay-1.3.2.tgz",
+      "integrity": "sha512-LNVEfjP+UuZMUGDtskPejsaCxhqhUv8+0hemAoFh5R8qW9S22gTADwWgf0DasoxEH3NFNHx7kDvxRjTTBeCAfg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-audio": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-audio/-/icon-audio-1.3.2.tgz",
+      "integrity": "sha512-5QWOFJNqK2Kf9jIyHyqaKw7Y3dwps+Wzfl+DfkfqvQrQfNpVe3sVdrpLHQSZ0f6G8ugcZQUvpblZpOh3lJqVwg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-bookmark": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-bookmark/-/icon-bookmark-1.3.2.tgz",
+      "integrity": "sha512-Q/8lSub0TxXkcKn55JfAjjLSzSZxcMFuZW6qgRmxKtawxx6ydBqV8ZJ0+Rg7tUpDU9AeSjOLOGivu/1h9CXXWA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-calendar": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-calendar/-/icon-calendar-1.3.2.tgz",
+      "integrity": "sha512-RT+uNtT2662XnuuLnTo5mlAWXRQkYu3fXQK+BPNyhIi52QWhvD11Ukts1eXJIaydgOfDjOEZm8mmWHw/4//IAw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-calendar-blank": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-calendar-blank/-/icon-calendar-blank-1.3.2.tgz",
+      "integrity": "sha512-4xu/V7j6IvJH/QRPd7Bumw85lRt+YnDqS/EotgiEDLX55BwVxFtKTbxle6NMAvsy4W+s6dhgzGZEcPGi3p4dpA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-close": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-0.3.2.tgz",
-      "integrity": "sha512-z3Z/Jl9qi1etI6Tt7nQnRk73grlIdWoYnMxX5trgH/9szZMUH6ofgUxR1vFTlqeTwswGWBX0vq3fYdTm+m2g7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-1.3.2.tgz",
+      "integrity": "sha512-4QhM/MDC1IsWQZoE3lt7A4l3/VOopJta+xVnDLqsbA3OW2sT+ilm/mUiP4l4Lm/NzdbQQwhnQMOZPcQvllxkzA==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-close-circle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close-circle/-/icon-close-circle-1.3.2.tgz",
+      "integrity": "sha512-xx1xtn99EuCV3l2eriuwzw27uvhXraS+mboIvaR7pArvGOKCeD4y9EEp0/QnBxVlNCOnz2dnWV3j9jnM+q1H0Q==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-collapse-sidebar": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-collapse-sidebar/-/icon-collapse-sidebar-1.1.0.tgz",
-      "integrity": "sha512-0P6NCdPsXBShnOXTwtc/+zpv27ibBVr/NnwNIVMIYfip89GCeQu7F60cNXuzDqZPhLsJKIymykT6ewJaFJ6Olw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-collapse-sidebar/-/icon-collapse-sidebar-1.3.2.tgz",
+      "integrity": "sha512-IMHMRMZsk7IssQHQz4VEZp+Md5pQVLXaFgcnFWcnWUOfVE7a9NKewckbpYG84vFCvhNT/v49uzid+SWlGLeYcA==",
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-credit-card": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-credit-card/-/icon-credit-card-1.3.2.tgz",
+      "integrity": "sha512-/CLBvqmtWN1a13JtjDdSGt461ukZdrzb+Ch6Hkg4T4AnqTSbucl3+3C5sBmNhjIisJGzEI2nxNIQHIlIu+WoIg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-dl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-dl/-/icon-dl-1.3.2.tgz",
+      "integrity": "sha512-QpvZzHzJdozMGAi1pPA/h9p6tEroIhdY9jJ70w0O0uCAo8d3zVetdYgJt1DGEpvOdP3Bp8now0MulKCz01n5lw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-donate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-donate/-/icon-donate-1.3.2.tgz",
+      "integrity": "sha512-vmyDImVpgcl5dxuqvdhcM4mZNQmHa+LSWKDcXlpEoiE8PZMtGAM4NNCz/mjp0E1lCvPQPckg63/hZ+hUkJdjQA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-edit-pencil": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-edit-pencil/-/icon-edit-pencil-1.3.2.tgz",
+      "integrity": "sha512-UfQsMCuuJqbdtSjcuOcMgbM52nfDKug+KajwOrea4QdKMS2pK6RAfOwGJ9geMFuXUs3NbJ4vmNq4R2LaghyDdQ==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-ellipses": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ellipses/-/icon-ellipses-0.3.2.tgz",
-      "integrity": "sha512-ohxkQZXfny/Ftwu4MIP7szrXA4H5/lDVZNXJ85LP9mjllfs20sF5bWGMAsO44GMiugQNbxZZhLgmcmxpz478jg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ellipses/-/icon-ellipses-1.3.2.tgz",
+      "integrity": "sha512-VcNbuWBqqRChVzjLb1qTwZdzVyN9fZF/kRcrR+f+mTzdbRUqyTwkN89//q+je+enHapNelAYwkX9tFr+GhnO8g==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-email": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-email/-/icon-email-1.3.2.tgz",
+      "integrity": "sha512-VzJ1Qsoal19+rZqEcwbsSzhFpV1Fn51hw2Qiq4pa7KAU6QzDMzJVkcvCK7bBOxLoVe3HwaeSMzKEXxr5h+VBfw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-facebook": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-facebook/-/icon-facebook-1.3.2.tgz",
+      "integrity": "sha512-sTBbBlya8jApRxhfFiNWKXmOiVQ6xCzz00tSJ5Puh7EIRQQhOEFgxmn8sCAIqmEN0fSnuFRElbERqsGrLBoxtw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-googlepay": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-googlepay/-/icon-googlepay-1.3.2.tgz",
+      "integrity": "sha512-lKEqkboTNIVNStpdkSaZUbA8MndC/c7+aACu5RAQjHo2i0IUwb5EzuUZkt86PMoXswJe+HtCHowFVkirFZ427w==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-ia-logo": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ia-logo/-/icon-ia-logo-0.3.2.tgz",
-      "integrity": "sha512-62D4i7toT/fCFRIVuhJTMXyMKUwO2ax0AvaQVuOnAjvbDGIjepl3fRUL3qfi7ArWPylYTDf9KY3g68rmYwkIJQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-ia-logo/-/icon-ia-logo-1.3.2.tgz",
+      "integrity": "sha512-lDZdaqj7A6nv5dJPaes6UZwDqlr3yMgaKJZSuMTqMUpjaZ0bcfDIoDFO4y2YjQ2uUHoRIgRNqyZVMSNJMowXzQ==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-images": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-images/-/icon-images-0.3.2.tgz",
-      "integrity": "sha512-hfqlzctiLvLCrxp+1MZLI8Bnk4WWD54VMD5QPa+t7uBdJuGfceXeSkxuTEwGDW6/bM4wXzhu/XaH+LL7Y5VimA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-images/-/icon-images-1.3.2.tgz",
+      "integrity": "sha512-VkqvoaVKiaEhYUx7O2nyG2qoa4YLQtTQXmmuE3G7JEUm6sxo02/hVYCeS/5EpsfaHkSn9xtTysSWghaic3QSSg==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-info": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-info/-/icon-info-1.3.2.tgz",
+      "integrity": "sha512-drkJWwFV4S9AH+/vkh8O5k+XclWxTqZoo/ELwt5dEsf7YiZKr5z80IetEZN5JeYh4OqoJJQfIJ81ZnjxJMlVzw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-link": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-link/-/icon-link-1.3.2.tgz",
+      "integrity": "sha512-NOZBXX1bXrAcNnBEPG0bdh8JcsQFdR3xf2VYJ9FeXLkCiJFXI3NaB/LG7ggkx2P4V10kC67hr52DX8MIDvZbtg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-locale-pin": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-locale-pin/-/icon-locale-pin-1.3.2.tgz",
+      "integrity": "sha512-wwsGwLMk5JMzEjgIvUwdZZo9Y8OKkvr0LuX3DVcaP/3t6XPTZngScst3NzcOav5+JHaAvKucRK8mI8tThSPZ9Q==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-lock": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-lock/-/icon-lock-1.3.2.tgz",
+      "integrity": "sha512-OwD0HC6SSIwN+oG0fmHM+desP7Pxw7X2bVoE55xHK4oA10l55DtMnbxzHb/HKVDltNvk9YaIV7/T+HgTa2heHA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-magnify-minus": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-minus/-/icon-magnify-minus-1.3.2.tgz",
+      "integrity": "sha512-Hb4d/phIcpgSon9NjAJ0hf1gVePLOMVx+H82M0yswLluJ4zuBGIpKD3hyDXmfsPS9/LW4SVczACuIw8DPocZ3A==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-magnify-plus": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-magnify-plus/-/icon-magnify-plus-1.3.2.tgz",
+      "integrity": "sha512-DBFrpdLhxFr0eXkszkeJqGBZIK8xApzfPUy9fmzTKvfq/z+N2E662Gqp8QXYg9VSP8uVW5YBS5rkRPVuuGRQ6g==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-paypal": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-paypal/-/icon-paypal-1.3.2.tgz",
+      "integrity": "sha512-X4IFJw/sSUjXV7OMqnftfkY1i22UvdgctUgf7/R4v7eJO4mhGQnwtH6DkBXzKbAt+FL9f1RhI1Wmz6WrxH19HQ==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-pinterest": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-pinterest/-/icon-pinterest-1.3.2.tgz",
+      "integrity": "sha512-UPmePtbTqqIK/uCqO5UZeFEgKOjKM6SxlUJCK6xAUAtUeSUv7dq4UywthNC8W5WfXvZGxGtAwioYt5Pddn43PQ==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-search": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-search/-/icon-search-0.3.2.tgz",
-      "integrity": "sha512-8hT8h1IZ3R32bdVlY+H5LHgvnr1BsOeckVH36QUmkiSfCdGC5MZ1KebVzEJle5EsME1bu/d18Za8oT/y/4ocLA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-search/-/icon-search-1.3.2.tgz",
+      "integrity": "sha512-L8pK/Om4oU6+n24Cm2GxYjEIyZzhJzXfSg2shnoNnzUt1WnjDsMGYgXEmjsx4Vq4DG6caTq7FZ5AOfxQ1Z2zIw==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-share": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.3.2.tgz",
+      "integrity": "sha512-XwMcznii1yW/f8lEHBQe974GKGsvgeter7AkXHPK3Fi2o2Jm7IDmT71zhb49mKKp66Vjr3lLgPWzPld+wZgnEA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-software": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-software/-/icon-software-1.3.2.tgz",
+      "integrity": "sha512-l/LAXCy8Gly/q32x0j6bmlNYbVIwicd6yrD83c+9cSCH4noHqZesFbm7TwunM6GXl8DpwCK6230ag01thxVkXQ==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-sort-ascending": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-ascending/-/icon-sort-ascending-1.3.2.tgz",
+      "integrity": "sha512-JibI67dO9pXJOBPBhLOUFrfngv7cFmM/U+2SmmADb9PsZ/VpMj1O60u/zxURhmF8XFzsLi0lpOKxizKoVGHFEg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-sort-descending": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-descending/-/icon-sort-descending-1.3.2.tgz",
+      "integrity": "sha512-ekMXJG8hwgtFCw7GRf00zW3rL/tXh1vWt/Je1RqdE4cudZCltiSwDizmHC2iVOL/Uz/DuuS2e3zK8448lzrrXw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-texts": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-texts/-/icon-texts-0.3.2.tgz",
-      "integrity": "sha512-r/8JIxtnRaAAT+k7zzcuAzklriilTSvApw0x/glbfrxhKlo+DF+9XKMnp0blR3bktJtSUJGY9O7MuFOxyz9HBQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-texts/-/icon-texts-1.3.2.tgz",
+      "integrity": "sha512-UBecBgGcCB894SaLTOvUbB5ayBRh+wOqrqwkdput0fHJTGZcMVgk04dZpHvShZq5nz2pGRzDK1ig1nwOzLhYnQ==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-toc": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-toc/-/icon-toc-1.3.2.tgz",
+      "integrity": "sha512-KYk5duzWsfS0bOKYN/jtMkKEOh2YhtmAdVT2RHc/oEh+5Pwa8Ujx0sp+x6NRUsbROwi2eJr8ui067memzFzWPw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-tumblr": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-tumblr/-/icon-tumblr-1.3.2.tgz",
+      "integrity": "sha512-IAFNpheZ2HujatnLC5Q70WdoIboJlMy8IkENOEZfTW/TfGiX0sdDkhEsOkI8wR5YDOX6C0R/LNPnUot5zjInaw==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-twitter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-twitter/-/icon-twitter-1.3.2.tgz",
+      "integrity": "sha512-aL1dizdh+LwOkE/6we7ZB/mXPN+4Hp/FsSDohI05X/NVu6c8nL5IeH2+BI6WS/knPUehBvh7lwGUzRFRwtqzCA==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-upload": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-upload/-/icon-upload-0.3.2.tgz",
-      "integrity": "sha512-a8w+TSvYT10HyV1DJiN45HcKW/jPysnYDyq+f4scN+c1F9XvwM1067HtKMcKP00zC3pwggs9BjpySRNtxu+WoA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-upload/-/icon-upload-1.3.2.tgz",
+      "integrity": "sha512-QdXk4PqeyYNjAI8Bey/cswEvcSPshQzTn5QMoWd0GZkaZ+fzuBwc9fmkc+tefcXcDd86D17MZZ7uudE4DnJENQ==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-user": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-user/-/icon-user-0.3.2.tgz",
-      "integrity": "sha512-z0fHHYAQZP2sDK/xht6xU6OteysvDxU36Mv8PmjWUI+5lrpucZVvgdNzzLlDXUAMsRsWkvnfGqieiqbhDpwOmQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-user/-/icon-user-1.3.2.tgz",
+      "integrity": "sha512-A5fCby40AEWWbrSSgGzhcSVDfL9M+S/Zl1oPTid/+mBuZPik0KPS5xoMBkT/952/ujbnLLR9URemzfPdSeBx+Q==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-venmo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-venmo/-/icon-venmo-1.3.2.tgz",
+      "integrity": "sha512-/gJ+/UpdBkqjo9L9zRL2BzUmHihcNCTyGybI8JShCPV0cW4NFIX9dr37cB70UuZpKdQZ5JsiJda0W8mPgO98aQ==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-video": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-video/-/icon-video-0.3.2.tgz",
-      "integrity": "sha512-lcJ6ggyJtd7Wbe9ZuTAUhbSQKDIatAi4tL4A2sYvqJtZzqm7C/+CMNr6uadgPOsY61DSFrpF7QrvNuBWOOyjvg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-video/-/icon-video-1.3.2.tgz",
+      "integrity": "sha512-wo1Cz6+4vLoGVAkhpscafBO8klr+YJsqSVGu7GbC4SWcJ1PcgcPJdpofMOHbDuTCbysc9QA5I+CENvnPHlsrcg==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
+      }
+    },
+    "@internetarchive/icon-visual-adjustment": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-visual-adjustment/-/icon-visual-adjustment-1.3.2.tgz",
+      "integrity": "sha512-eqnHimIaDJ3SfFGChg+43H1jjW4XEsbMYHrgXOLFUR/0PtUIFkb0Mvv39YUD64B7uqQZTFbLvyabmxrQQYFQLg==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-volumes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-volumes/-/icon-volumes-1.1.0.tgz",
-      "integrity": "sha512-wBVzs6TxG7CGRth6yQ3DqWE2LJnZaA+AhiQ/dJEevtmHDV7pRIib5VbYlpd64gWGU5fcAxamfLSVQArwVoOEeQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-volumes/-/icon-volumes-1.3.2.tgz",
+      "integrity": "sha512-Hi7P1FXae4USSaF4eQYPTz5fZfvIBjRCm7Li0IgGz0vmsJGVA5aRgwcQHvcjsSuLfEJP6lJ9skRd6srSWe08fg==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "@internetarchive/icon-web": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-web/-/icon-web-0.3.2.tgz",
-      "integrity": "sha512-qLBWwFE3xwik+RDB+p0LowGaY6AcuO/X+2SPN1pqvCE+68O7J9sLsg9gUagG5olcIant82VpRLHSjD1WfZ//iA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-web/-/icon-web-1.3.2.tgz",
+      "integrity": "sha512-WWHcPKRud2ZWZTvxSgqLbugkSuSgXypxiMU864P6dreNGZMwVoGnkke6/1Zc73hMy3XIqdEWtLUEQsbbagc1Rw==",
       "dev": true,
       "requires": {
-        "lit-html": "^1.2.1"
+        "lit": "^2.0.2"
       }
     },
     "@koa/cors": {
@@ -15812,6 +16394,11 @@
       "requires": {
         "vary": "^1.1.2"
       }
+    },
+    "@lit/reactive-element": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.3.tgz",
+      "integrity": "sha512-fu0HW3VpeQdTx2BxjcMD0pEXB6M3xYi7Cgmqr7+jtyN7hNZJGFWqqQFfyJRwP8cBGQz3WW1txBiPPf9dK2xdUg=="
     },
     "@mdjs/core": {
       "version": "0.3.3",
@@ -16888,6 +17475,11 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "@types/uglify-js": {
       "version": "3.9.3",
@@ -21908,10 +22500,40 @@
         }
       }
     },
+    "lit": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.4.tgz",
+      "integrity": "sha512-m1tHAZdXQhiBe0ReAjyVIUeKnHZpBfx+A5R5dkia8dtvIBwOR6KhD+RxaDnCwrEavRqkZAy5ntLv7chiOZCdNg==",
+      "requires": {
+        "@lit/reactive-element": "^1.1.0",
+        "lit-element": "^3.1.0",
+        "lit-html": "^2.1.0"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.2.tgz",
+          "integrity": "sha512-5VLn5a7anAFH7oz6d7TRG3KiTZQ5GEFsAgOKB8Yc+HDyuDUGOT2cL1CYTz/U4b/xlJxO+euP14pyji+z3Z3kOg==",
+          "requires": {
+            "@lit/reactive-element": "^1.1.0",
+            "lit-html": "^2.1.0"
+          }
+        },
+        "lit-html": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.3.tgz",
+          "integrity": "sha512-WgvdwiNeuoT0mYEEJI+AAV2DEtlqzVM4lyDSaeQSg5ZwhS/CkGJBO/4n66alApEuSS9WXw9+ADBp8SPvtDEKSg==",
+          "requires": {
+            "@types/trusted-types": "^2.0.2"
+          }
+        }
+      }
+    },
     "lit-element": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
       "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "dev": true,
       "requires": {
         "lit-html": "^1.1.1"
       }
@@ -21919,7 +22541,8 @@
     "lit-html": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+      "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,12 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
-    "@internetarchive/icon-collapse-sidebar": "^1.1.0",
-    "lit-element": "^2.2.1",
-    "lit-html": "^1.1.2"
+    "@internetarchive/icon-collapse-sidebar": "^1.3.2",
+    "lit": "^2.1.4"
   },
   "devDependencies": {
-    "@internetarchive/ia-icons": "0.3.0",
-    "@internetarchive/icon-volumes": "^1.1.0",
+    "@internetarchive/ia-icons": "^1.3.2",
+    "@internetarchive/icon-volumes": "^1.3.2",
     "@open-wc/demoing-storybook": "^2.0.0",
     "@open-wc/eslint-config": "^2.0.0",
     "@open-wc/testing": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-menu-slider",
-  "version": "1.1.1",
+  "version": "1.1.3-a1",
   "description": "Menu slider used in ia-topnav",
   "author": "ia-menu-slider",
   "license": "MIT",

--- a/src/ia-menu-slider.js
+++ b/src/ia-menu-slider.js
@@ -1,5 +1,5 @@
-import { nothing } from 'lit-html';
-import { LitElement, html } from 'lit-element';
+import { nothing } from 'lit/html.js';
+import { LitElement, html } from 'lit';
 import menuSliderCSS from './styles/menu-slider.js';
 import '@internetarchive/icon-collapse-sidebar/icon-collapse-sidebar.js';
 import './menu-button.js';

--- a/src/menu-button.js
+++ b/src/menu-button.js
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit-element';
+import { html, LitElement } from 'lit';
 import menuButtonCSS from './styles/menu-button.js';
 
 class MenuButton extends LitElement {

--- a/src/styles/menu-button.js
+++ b/src/styles/menu-button.js
@@ -1,4 +1,4 @@
-import { css } from 'lit-element';
+import { css } from 'lit';
 
 export default css`
   a {
@@ -52,7 +52,8 @@ export default css`
     position: relative;
     display: inline-flex;
     z-index: 2;
-    width: 4.2rem;
+    min-width: 4.2rem;
+    max-width: 4.2rem;
     height: 4.2rem;
     vertical-align: middle;
     -webkit-box-align: center;

--- a/src/styles/menu-slider.js
+++ b/src/styles/menu-slider.js
@@ -1,4 +1,4 @@
-import { css } from 'lit-element';
+import { css } from 'lit';
 
 const menuButtonWidth = css`42px`;
 const sliderWidth = css`var(--menuWidth, 320px)`;


### PR DESCRIPTION
upgrades menu slider to lit2 + demo using latest `<ia-icons>` that are also in lit2

[lit upgrade docs](https://lit.dev/docs/releases/upgrade/)


to do: tests

<img width="346" alt="image" src="https://user-images.githubusercontent.com/7840857/154549413-7da5cdc9-6f9b-4fc6-b1bf-8ec4450f2373.png">
